### PR TITLE
Stripping general Bootstrap CSS

### DIFF
--- a/admin/css/sass/admin.scss
+++ b/admin/css/sass/admin.scss
@@ -1,2 +1,21 @@
-@import "partials/*.scss";
-@import "shortcodes/*.scss";
+// Partials
+@import "partials/brand-colors";
+@import "partials/bugfixes";
+@import "partials/fonts";
+@import "partials/icons";
+@import "partials/misc";
+@import "partials/tinymce";
+@import "partials/variables";
+
+// Shortcodes
+
+@import "shortcodes/class-alert";
+// @import "shortcodes/class-basebutton";
+@import "shortcodes/class-button";
+@import "shortcodes/class-callout";
+// @import "shortcodes/class-col";
+@import "shortcodes/class-iconbox";
+// @import "shortcodes/class-lead";
+@import "shortcodes/class-panel";
+@import "shortcodes/class-pullquote";
+@import "shortcodes/class-textbox";

--- a/admin/css/sass/partials/brand-colors.scss
+++ b/admin/css/sass/partials/brand-colors.scss
@@ -1,595 +1,263 @@
+@mixin brand-colors($background-color, $color, $other-color) {
+    background-color: $background-color;
+    color: $color;
+
+    [class^="ic-"]:before,
+    [class*=" ic-"],
+    [class^="i-"]:before,
+    [class*=" i-"],
+    .callout-heading {
+        color: $other-color;
+    }
+}
+
+@mixin brand-colors-links($color, $border-color, $hover-color, $hover-border-color, $visited-color, $visited-border-color) {
+    color: $color;
+    border-bottom-color: $border-bottom-color;
+
+    &:hover,
+    &:active,
+    &:focus {
+        color: $hover-color;
+        border-bottom-color: $hover-border-color;
+    }
+    &:visited {
+        color: $visited-color;
+        border-bottom-color: $visited-border-color;
+    }
+}
+
+@mixin brand-colors-classed-link($background-color, $color, $border-color) {
+    &:hover,
+    &:active,
+    &:focus {
+        background-color: $background-color;
+        color: $color;
+        border-bottom-color: $border-color;
+    }
+}
 
 .darken {
-  background-color: rgba(0,0,0,0.5);
+    background-color: rgba(0, 0, 0, 0.5);
 }
 
 .lighten {
-  background-color: rgba(255,255,255,0.5);
+    background-color: rgba(255, 255, 255, 0.5);
 }
 
 .transparentwhite {
-  background-color: none;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(none, #fff, #fff);
 }
 
 .transparentblack {
-  background-color: none;
-  color: #212121;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #212121;
-  }
+    @include brand-colors(none, #212121, #212121);
 }
 
 .transparentred {
-  background-color: none;
-  color: #9d2235;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #9d2235;
-  }
+    @include brand-colors(none, #9d2235, #9d2235);
 }
 
 .semidark {
-  background-color: rgba(0,0,0,0.5);
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(rgba(0, 0, 0, 0.5), #fff, #fff);
 }
 
 .semilight {
-  background-color: rgba(255,255,255,0.5);
-  color: #212121;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #212121;
-  }
+    @include brand-colors(rgba(255, 255, 255, 0.5), #212121, #212121);
 }
 
 .black {
-  background-color: #000;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#000, #fff, #fff);
 }
 
 .white {
-  background-color: #fff;
-  color: #212121;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #212121;
-  }
+    @include brand-colors(#fff, #212121, #212121);
 }
 
 .gray5 {
-  background-color: #FAF8F9;
-  color: #212121;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #212121;
-  }
+    @include brand-colors(#faf8f9, #212121, #212121);
 }
 
 .gray10 {
-  background-color: #F5F3F4;
-  color: #212121;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #212121;
-  }
+    @include brand-colors(#f5f3f4, #212121, #212121);
 }
 
 .gray25 {
-  background-color: #DCDADB;
-  color: #212121;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #212121;
-  }
+    @include brand-colors(#dcdadb, #212121, #212121);
 }
 
 .gray60 {
-  background-color: #767475;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#767475, #fff, #fff);
 }
 
 .gray90 {
-  background-color: #212121;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"], {
-    color: #fff;
-  }
+    @include brand-colors(#212121, #fff, #fff);
 }
 
 .uamsred {
-  background-color: #9d2235;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#9d2235, #fff, #fff);
 }
 
 .accentgray {
-  background-color: #767475;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#767475, #fff, #fff);
 }
 
 .eggplant {
-  background-color: #701D45;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#701d45, #fff, #fff);
 }
 
 .bluegray {
-  background-color: #396079;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#396079, #fff, #fff);
 }
 
 .darkblue {
-  background-color: #1A365C;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#1a365c, #fff, #fff);
 }
 
 .maroon {
-  background-color: #6C0020;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#6c0020, #fff, #fff);
 }
 
 .orange {
-  background-color: #CA4C1D;
-  color: #fff;
-
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#ca4c1d, #fff, #fff);
 }
 
 .lightblue {
-  background-color: #01809F;
-  color: #fff;
-  
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#01809f, #fff, #fff);
 }
 
 .tealblue {
-  background-color: #427F81;
-  color: #fff;
-  
-  [class^="ic-"]:before, [class*=" ic-"], 
-[class^="i-"]:before, [class*=" i-"],,
-  .callout-heading {
-    color: #fff;
-  }
+    @include brand-colors(#427f81, #fff, #fff);
 }
 
 /* ===== 1.2 - Brand Colors - Links ===== */
 
 .transparentwhite a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .transparentblack a {
-  color: #212121;
-  border-bottom-color: #212121;
-
-  &:hover, &:active, &:focus {
-    color: #2A2829;
-    border-bottom-color: #2A2829;
-  }
-  &:visited {
-    color: #434142;
-    border-bottom-color: #434142;
-  }
+    @include brand-colors-links(#212121, #212121, #2a2829, #2a2829, #434142, #434142);
 }
 
 .transparentred a {
-  color: #cc0000;
-  border-bottom-color: #cc0000;
-
-  &:hover, &:active, &:focus {
-    color: #990000;
-    border-bottom-color: #990000;
-  }
-  &:visited {
-    color: #aa0000;
-    border-bottom-color: #aa0000;
-  }
+    @include brand-colors-links(#cc0000, #cc0000, #990000, #990000, #aa0000, #aa0000);
 }
 
 .black a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .white a {
-  color: #212121;
-  border-bottom-color: #212121;
-
-  &:hover, &:active, &:focus {
-    color: #2A2829;
-    border-bottom-color: #2A2829;
-  }
-  &:visited {
-    color: #434142;
-    border-bottom-color: #434142;
-  }
+    @include brand-colors-links(#212121, #212121, #2a2829, #2a2829, #434142, #434142);
 }
 
 .gray10 a {
-  color: #212121;
-  border-bottom-color: #212121;
-
-  &:hover, &:active, &:focus {
-    color: #2A2829;
-    border-bottom-color: #2A2829;
-  }
-  &:visited {
-    color: #434142;
-    border-bottom-color: #434142;
-  }
+    @include brand-colors-links(#212121, #212121, #2a2829, #2a2829, #434142, #434142);
 }
 
 .gray25 a {
-  color: #212121;
-  border-bottom-color: #212121;
-
-  &:hover, &:active, &:focus {
-    color: #2A2829;
-    border-bottom-color: #2A2829;
-  }
-  &:visited {
-    color: #434142;
-    border-bottom-color: #434142;
-  }
+    @include brand-colors-links(#212121, #212121, #2a2829, #2a2829, #434142, #434142);
 }
 
 .gray60 a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #f5f3f4, #f5f3f4);
 }
 
 .gray90 a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .uamsred a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .accentgray a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .eggplant a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .bluegray a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .maroon a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .orange a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .lightblue a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
 .tealblue a {
-  color: #fff;
-  border-bottom-color: #fff;
-
-  &:hover, &:active, &:focus {
-    color: #F5F3F4;
-    border-bottom-color: #F5F3F4;
-  }
-  &:visited {
-    color: #DCDADB;
-    border-bottom-color: #DCDADB;
-  }
+    @include brand-colors-links(#fff, #fff, #f5f3f4, #f5f3f4, #dcdadb, #dcdadb);
 }
 
+
 a {
-  &.black {
-    &:hover, &:active, &:focus {
-      color: #fff;
-      border-bottom-color: #fff;
+    &.black {
+        @include brand-colors-classed-link(#000, #fff, #fff);
     }
-  }
 
-  &.white {
-    &:hover, &:active, &:focus {
-      background-color: #F0EEEF;
-      color: #212121;
-      border-bottom-color: #212121;
+    &.white {
+        @include brand-colors-classed-link(#f0eeef, #212121, #212121);
     }
-  }
 
-  &.gray10 {
-    &:hover, &:active, &:focus {
-      background-color: #DCDADB;
-      color: #212121;
-      border-bottom-color: #212121;
+    &.gray10 {
+        @include brand-colors-classed-link(#dcdadb, #212121, #212121);
     }
-  }
 
-  &.gray25 {
-    &:hover, &:active, &:focus {
-      background-color: #A9A7A8;
-      color: #212121;
-      border-bottom-color: #212121;
+    &.gray25 {
+        @include brand-colors-classed-link(#a9a7a8, #212121, #212121);
     }
-  }
 
-  &.gray60 {
-    &:hover, &:active, &:focus {
-      background-color: #434142;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.gray60 {
+        @include brand-colors-classed-link(#434142, #fff, #fff);
     }
-  }
 
-  &.gray90 {
-    &:hover, &:active, &:focus {
-      background-color: #1a1a1a;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.gray90 {
+        @include brand-colors-classed-link(#1a1a1a, #fff, #fff);
     }
-  }
 
-  &.uamsred {
-    &:hover, &:active, &:focus {
-      background-color: #9d2235;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.uamsred {
+        @include brand-colors-classed-link(#9d2235, #fff, #fff);
     }
-  }
 
-  &.accentgray {
-    &:hover, &:active, &:focus {
-      background-color: #767475;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.accentgray {
+        @include brand-colors-classed-link(#767475, #fff, #fff);
     }
-  }
 
-  &.eggplant {
-    &:hover, &:active, &:focus {
-      background-color: #701D45;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.eggplant {
+        @include brand-colors-classed-link(#701d45, #fff, #fff);
     }
-  }
 
-  &.bluegray {
-    &:hover, &:active, &:focus {
-      background-color: #396079;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.bluegray {
+        @include brand-colors-classed-link(#396079, #fff, #fff);
     }
-  }
 
-  &.darkblue {
-    &:hover, &:active, &:focus {
-      background-color: #1A365C;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.darkblue {
+        @include brand-colors-classed-link(#1a365c, #fff, #fff);
     }
-  }
 
-  &.maroon {
-    &:hover, &:active, &:focus {
-      background-color: #6C0020;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.maroon {
+        @include brand-colors-classed-link(#6c0020, #fff, #fff);
     }
-  }
 
-  &.orange {
-    &:hover, &:active, &:focus {
-      background-color: #CA4C1D;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.orange {
+        @include brand-colors-classed-link(#ca4c1d, #fff, #fff);
     }
-  }
 
-  &.lightblue {
-    &:hover, &:active, &:focus {
-      background-color: #01809F;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.lightblue {
+        @include brand-colors-classed-link(#01809f, #fff, #fff);
     }
-  }
 
-  &.tealblue {
-    &:hover, &:active, &:focus {
-      background-color: #427F81;
-      color: #fff;
-      border-bottom-color: #fff;
+    &.tealblue {
+        @include brand-colors-classed-link(#427f81, #fff, #fff);
     }
-  }
 }

--- a/admin/css/sass/shortcodes/class-alert.scss
+++ b/admin/css/sass/shortcodes/class-alert.scss
@@ -1,26 +1,26 @@
 .alert {
-	padding: 0 !important;
-	border-radius: 0 !important;
-	border: solid 0.15em !important;
-	background-color: #fff !important;
-	color: #000 !important;
-	display: flex;
-	flex-direction: row;
+	// padding: 0 !important;
+	// border-radius: 0 !important;
+	// border: solid 0.15em !important;
+	// background-color: #fff !important;
+	// color: #000 !important;
+	// display: flex;
+	// flex-direction: row;
 
 	button.close {
-		align-self: flex-end;
-		margin: 0 0 auto auto;
-		padding: 0 0.3em 0.4em 0.4em;
-		opacity: 0.6;
-		background: none;
-		border: 0;
-    	font-size: 32px;
-    	font-family: 'Fira Sans', sans-serif;
-    	font-weight: bold;
-    	line-height: 1em;
+		// align-self: flex-end;
+		// margin: 0 0 auto auto;
+		// padding: 0 0.3em 0.4em 0.4em;
+		// opacity: 0.6;
+		// background: none;
+		// border: 0;
+    	// font-size: 32px;
+    	// font-family: 'Fira Sans', sans-serif;
+    	// font-weight: bold;
+    	// line-height: 1em;
 
 		&:hover, &:active, &:focus {
-			opacity: 1;
+			// opacity: 1;
 		}
 	}
 }
@@ -64,9 +64,9 @@
 }
 
 .alert-success {
-	color: #000;
-	background-color: #fff;
-	border-color: $webgreen !important;
+	// color: #000;
+	// background-color: #fff;
+	// border-color: $webgreen !important;
 
 	.alert-icon {
 		color: #fff;
@@ -75,9 +75,9 @@
 }
 
 .alert-info {
-	color: #000;
-	background-color: #fff;
-	border-color: $bluegray !important;
+	// color: #000;
+	// background-color: #fff;
+	// border-color: $bluegray !important;
 
 	.alert-icon {
 		color: #fff;
@@ -86,9 +86,9 @@
 }
 
 .alert-warning {
-	color: #000;
-	background-color: #fff;
-	border-color: $focusyellow !important;
+	// color: #000;
+	// background-color: #fff;
+	// border-color: $focusyellow !important;
 
 	.alert-icon {
 		color: #000;
@@ -101,9 +101,9 @@
 }
 
 .alert-danger {
-	color: #000;
-	background-color: #fff;
-	border-color: $urgentred !important;
+	// color: #000;
+	// background-color: #fff;
+	// border-color: $urgentred !important;
 
 	.alert-icon {
 		color: #fff;
@@ -124,8 +124,8 @@
 
 @media screen and (max-width: 768px) {
 	.alert {
-		display: flex;
-		flex-direction: column;
+		// display: flex;
+		// flex-direction: column;
 	}
 	
 	.alert-icon {

--- a/admin/css/sass/shortcodes/class-basebutton.scss
+++ b/admin/css/sass/shortcodes/class-basebutton.scss
@@ -1,79 +1,79 @@
 /* Bootstrap Button CSS */
 button {
-  background-color: #bdbdbd;
-  border-radius: 0;
+    background-color: #bdbdbd;
+    border-radius: 0;
 }
 button:hover,
 button:focus {
-  background-color: #b0b0b0;
+    background-color: #b0b0b0;
 }
 .btn {
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: normal;
-  text-align: center;
-  vertical-align: middle;
-  cursor: pointer;
-  background-image: none;
-  border: 1px solid transparent;
-  white-space: nowrap;
-  padding: 6px 12px;
-  font-size: 19px;
-  line-height: 1.72222;
-  border-radius: 0;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
-  user-select: none;
+    display: inline-block;
+    margin-bottom: 0;
+    font-weight: normal;
+    text-align: center;
+    vertical-align: middle;
+    cursor: pointer;
+    background-image: none;
+    border: 1px solid transparent;
+    white-space: nowrap;
+    padding: 6px 12px;
+    font-size: 19px;
+    line-height: 1.72222;
+    border-radius: 0;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -o-user-select: none;
+    user-select: none;
 }
 .btn:focus,
 .btn:active:focus,
 .btn.active:focus {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
+    outline: thin dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px;
 }
 .btn:hover,
 .btn:focus {
-  color: #212121;
-  text-decoration: none;
+    color: #212121;
+    text-decoration: none;
 }
 .btn:active,
 .btn.active {
-  outline: 0;
-  background-image: none;
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    outline: 0;
+    background-image: none;
+    -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
 .btn.disabled,
 .btn[disabled],
 fieldset[disabled] .btn {
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: 0.65;
-  filter: alpha(opacity=65);
-  -webkit-box-shadow: none;
-  box-shadow: none;
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: 0.65;
+    filter: alpha(opacity=65);
+    -webkit-box-shadow: none;
+    box-shadow: none;
 }
 .btn-default {
-  color: #212121;
-  background-color: #ffffff;
-  border-color: #424242;
+    color: #212121;
+    background-color: #ffffff;
+    border-color: #424242;
 }
 .btn-default:hover,
 .btn-default:focus,
 .btn-default:active,
 .btn-default.active,
 .open > .dropdown-toggle.btn-default {
-  color: #212121;
-  background-color: #e6e6e6;
-  border-color: #232323;
+    color: #212121;
+    background-color: #e6e6e6;
+    border-color: #232323;
 }
 .btn-default:active,
 .btn-default.active,
 .open > .dropdown-toggle.btn-default {
-  background-image: none;
+    background-image: none;
 }
 .btn-default.disabled,
 .btn-default[disabled],
@@ -90,31 +90,31 @@ fieldset[disabled] .btn-default:active,
 .btn-default.disabled.active,
 .btn-default[disabled].active,
 fieldset[disabled] .btn-default.active {
-  background-color: #ffffff;
-  border-color: #424242;
+    background-color: #ffffff;
+    border-color: #424242;
 }
 .btn-default .badge {
-  color: #ffffff;
-  background-color: #212121;
+    color: #ffffff;
+    background-color: #212121;
 }
 .btn-primary {
-  color: #ffffff;
-  background-color: #9d2235;
-  border-color: #881d2e;
+    color: #ffffff;
+    background-color: #9d2235;
+    border-color: #881d2e;
 }
 .btn-primary:hover,
 .btn-primary:focus,
 .btn-primary:active,
 .btn-primary.active,
 .open > .dropdown-toggle.btn-primary {
-  color: #ffffff;
-  background-color: #731927;
-  border-color: #56131d;
+    color: #ffffff;
+    background-color: #731927;
+    border-color: #56131d;
 }
 .btn-primary:active,
 .btn-primary.active,
 .open > .dropdown-toggle.btn-primary {
-  background-image: none;
+    background-image: none;
 }
 .btn-primary.disabled,
 .btn-primary[disabled],
@@ -131,31 +131,31 @@ fieldset[disabled] .btn-primary:active,
 .btn-primary.disabled.active,
 .btn-primary[disabled].active,
 fieldset[disabled] .btn-primary.active {
-  background-color: #9d2235;
-  border-color: #881d2e;
+    background-color: #9d2235;
+    border-color: #881d2e;
 }
 .btn-primary .badge {
-  color: #9d2235;
-  background-color: #ffffff;
+    color: #9d2235;
+    background-color: #ffffff;
 }
 .btn-success {
-  color: #ffffff;
-  background-color: #1b7d3d;
-  border-color: #166833;
+    color: #ffffff;
+    background-color: #1b7d3d;
+    border-color: #166833;
 }
 .btn-success:hover,
 .btn-success:focus,
 .btn-success:active,
 .btn-success.active,
 .open > .dropdown-toggle.btn-success {
-  color: #ffffff;
-  background-color: #125329;
-  border-color: #0c361a;
+    color: #ffffff;
+    background-color: #125329;
+    border-color: #0c361a;
 }
 .btn-success:active,
 .btn-success.active,
 .open > .dropdown-toggle.btn-success {
-  background-image: none;
+    background-image: none;
 }
 .btn-success.disabled,
 .btn-success[disabled],
@@ -172,31 +172,31 @@ fieldset[disabled] .btn-success:active,
 .btn-success.disabled.active,
 .btn-success[disabled].active,
 fieldset[disabled] .btn-success.active {
-  background-color: #1b7d3d;
-  border-color: #166833;
+    background-color: #1b7d3d;
+    border-color: #166833;
 }
 .btn-success .badge {
-  color: #1b7d3d;
-  background-color: #ffffff;
+    color: #1b7d3d;
+    background-color: #ffffff;
 }
 .btn-info {
-  color: #ffffff;
-  background-color: #22739d;
-  border-color: #1d6488;
+    color: #ffffff;
+    background-color: #22739d;
+    border-color: #1d6488;
 }
 .btn-info:hover,
 .btn-info:focus,
 .btn-info:active,
 .btn-info.active,
 .open > .dropdown-toggle.btn-info {
-  color: #ffffff;
-  background-color: #195473;
-  border-color: #133f56;
+    color: #ffffff;
+    background-color: #195473;
+    border-color: #133f56;
 }
 .btn-info:active,
 .btn-info.active,
 .open > .dropdown-toggle.btn-info {
-  background-image: none;
+    background-image: none;
 }
 .btn-info.disabled,
 .btn-info[disabled],
@@ -213,31 +213,31 @@ fieldset[disabled] .btn-info:active,
 .btn-info.disabled.active,
 .btn-info[disabled].active,
 fieldset[disabled] .btn-info.active {
-  background-color: #22739d;
-  border-color: #1d6488;
+    background-color: #22739d;
+    border-color: #1d6488;
 }
 .btn-info .badge {
-  color: #22739d;
-  background-color: #ffffff;
+    color: #22739d;
+    background-color: #ffffff;
 }
 .btn-warning {
-  color: #212121;
-  background-color: #f1c40f;
-  border-color: #dab10d;
+    color: #212121;
+    background-color: #f1c40f;
+    border-color: #dab10d;
 }
 .btn-warning:hover,
 .btn-warning:focus,
 .btn-warning:active,
 .btn-warning.active,
 .open > .dropdown-toggle.btn-warning {
-  color: #212121;
-  background-color: #c29d0b;
-  border-color: #a08209;
+    color: #212121;
+    background-color: #c29d0b;
+    border-color: #a08209;
 }
 .btn-warning:active,
 .btn-warning.active,
 .open > .dropdown-toggle.btn-warning {
-  background-image: none;
+    background-image: none;
 }
 .btn-warning.disabled,
 .btn-warning[disabled],
@@ -254,31 +254,31 @@ fieldset[disabled] .btn-warning:active,
 .btn-warning.disabled.active,
 .btn-warning[disabled].active,
 fieldset[disabled] .btn-warning.active {
-  background-color: #f1c40f;
-  border-color: #dab10d;
+    background-color: #f1c40f;
+    border-color: #dab10d;
 }
 .btn-warning .badge {
-  color: #f1c40f;
-  background-color: #212121;
+    color: #f1c40f;
+    background-color: #212121;
 }
 .btn-danger {
-  color: #ffffff;
-  background-color: #e74c3c;
-  border-color: #e43725;
+    color: #ffffff;
+    background-color: #e74c3c;
+    border-color: #e43725;
 }
 .btn-danger:hover,
 .btn-danger:focus,
 .btn-danger:active,
 .btn-danger.active,
 .open > .dropdown-toggle.btn-danger {
-  color: #ffffff;
-  background-color: #d62c1a;
-  border-color: #b62516;
+    color: #ffffff;
+    background-color: #d62c1a;
+    border-color: #b62516;
 }
 .btn-danger:active,
 .btn-danger.active,
 .open > .dropdown-toggle.btn-danger {
-  background-image: none;
+    background-image: none;
 }
 .btn-danger.disabled,
 .btn-danger[disabled],
@@ -295,58 +295,58 @@ fieldset[disabled] .btn-danger:active,
 .btn-danger.disabled.active,
 .btn-danger[disabled].active,
 fieldset[disabled] .btn-danger.active {
-  background-color: #e74c3c;
-  border-color: #e43725;
+    background-color: #e74c3c;
+    border-color: #e43725;
 }
 .btn-danger .badge {
-  color: #e74c3c;
-  background-color: #ffffff;
+    color: #e74c3c;
+    background-color: #ffffff;
 }
 .btn-link {
-  color: #1565c0;
-  font-weight: normal;
-  cursor: pointer;
-  border-radius: 0;
+    color: #1565c0;
+    font-weight: normal;
+    cursor: pointer;
+    border-radius: 0;
 }
 .btn-link,
 .btn-link:active,
 .btn-link[disabled],
 fieldset[disabled] .btn-link {
-  background-color: transparent;
-  -webkit-box-shadow: none;
-  box-shadow: none;
+    background-color: transparent;
+    -webkit-box-shadow: none;
+    box-shadow: none;
 }
 .btn-link,
 .btn-link:hover,
 .btn-link:focus,
 .btn-link:active {
-  border-color: transparent;
+    border-color: transparent;
 }
 .btn-link:hover,
 .btn-link:focus {
-  color: #9d2235;
-  text-decoration: underline;
-  background-color: transparent;
+    color: #9d2235;
+    text-decoration: underline;
+    background-color: transparent;
 }
 .btn-link[disabled]:hover,
 fieldset[disabled] .btn-link:hover,
 .btn-link[disabled]:focus,
 fieldset[disabled] .btn-link:focus {
-  color: #bdc3c7;
-  text-decoration: none;
+    color: #bdc3c7;
+    text-decoration: none;
 }
 .btn-lg {
-  padding: 10px 16px;
-  font-size: 24px;
-  line-height: 1.33;
+    padding: 10px 16px;
+    font-size: 24px;
+    line-height: 1.33;
 }
 .btn-sm {
-  padding: 5px 10px;
-  font-size: 17px;
-  line-height: 1.5;
+    padding: 5px 10px;
+    font-size: 17px;
+    line-height: 1.5;
 }
 .btn-xs {
-  padding: 1px 5px;
-  font-size: 17px;
-  line-height: 1.5;
+    padding: 1px 5px;
+    font-size: 17px;
+    line-height: 1.5;
 }

--- a/admin/css/sass/shortcodes/class-button.scss
+++ b/admin/css/sass/shortcodes/class-button.scss
@@ -1,276 +1,319 @@
 .uams-button {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-  border: 0 !important;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+    border: 0 !important;
 
-  .btn-content {
-    padding: 0 0.5em;
-  }
-
-  svg {
-    height: 1.25em;
-    width: 1.25em;
-    margin: -0.25em 0;
-    fill: #fff;
-  }
-
-  &.white {
-    color: $uamsred;
+    .btn-content {
+        padding: 0 0.5em;
+    }
 
     svg {
-      fill: $uamsred;
+        height: 1.25em;
+        width: 1.25em;
+        margin: -0.25em 0;
+        fill: #fff;
     }
 
-    &:hover, &:focus, &:active {
-      color: darken( $uamsred, 10 );
+    &.white {
+        color: $uamsred;
 
-      svg {
-        fill: darken( $uamsred, 10 );
-      }
+        svg {
+            fill: $uamsred;
+        }
+
+        &:hover,
+        &:focus,
+        &:active {
+            color: darken($uamsred, 10);
+
+            svg {
+                fill: darken($uamsred, 10);
+            }
+        }
     }
-  }
 }
 
 /* UAMS Buttons */
+
 a.uams-btn {
-  padding: 11px 20px;
-  text-transform: uppercase;
-  background-color: #e0e0e0;
-  font-family: "Fira Sans", sans-serif;
-  font-weight: 800;
-  color: #616161;
-  display: inline-block;
-  position: relative;
-  background-image: none !important;
-  border-bottom: none;
-  margin-bottom: 25px;
-  margin-right: 65px;
-  z-index: 1;
-  line-height: 24px;
-  font-size: 17px;
+    padding: 11px 20px;
+    text-transform: uppercase;
+    background-color: #e0e0e0;
+    font-family: "Fira Sans", sans-serif;
+    font-weight: 800;
+    color: #616161;
+    display: inline-block;
+    position: relative;
+    background-image: none !important;
+    border-bottom: none;
+    margin-bottom: 25px;
+    margin-right: 65px;
+    z-index: 1;
+    line-height: 24px;
+    font-size: 17px;
+
+    &:hover,
+    &:focus {
+        color: #212121;
+        background-color: #9d2235;
+
+        &:before {
+            background-color: #c72b43;
+        }
+    }
+
+    &.btn-sm {
+        padding: 8px 14px;
+        font-size: 15px;
+        font-weight: 800;
+        border-radius: 0;
+        -webkit-border-radius: 0;
+        -moz-border-radius: 0;
+
+        &:before {
+            width: 43px;
+            right: -43px;
+        }
+
+        &:after {
+            width: 45px;
+            height: 45px;
+            top: 50%;
+            margin-top: -21px;
+            right: -43px;
+            background-size: 740px;
+            background-position: -32px -410px;
+        }
+
+        &.btn-left {
+            margin-left: 43px;
+
+            &:before {
+                left: -43px;
+                border-right: 5px solid rgba(0, 0, 0, 0.3);
+                border-left: none;
+            }
+
+            &:after {
+                left: -43px;
+                margin-top: -25px;
+                transform: rotate(180deg);
+                -ms-transform: rotate(180deg);
+                -webkit-transform: rotate(180deg);
+            }
+        }
+
+        &.btn-play:after {
+            background-position: -30px -464px;
+        }
+
+        &.btn-external:after {
+            background-position: -126px -410px;
+        }
+
+        &.btn-plus:after {
+            background-position: -83px -465px;
+        }
+    }
+
+    &.btn-lg {
+        padding: 16px 30px;
+        font-size: 24px;
+        font-weight: 800;
+        border-radius: 0;
+        -webkit-border-radius: 0;
+        -moz-border-radius: 0;
+
+        &:before {
+            width: 60px;
+            right: -60px;
+        }
+
+        &:after {
+            width: 64px;
+            height: 56px;
+            top: 50%;
+            margin-top: -30px;
+            right: -60px;
+            background-size: 1000px;
+            background-position: -38px -550px;
+        }
+
+        &.btn-play:after {
+            background-position: -39px -625px;
+        }
+
+        &.btn-external:after {
+            background-position: -166px -550px;
+        }
+
+        &.btn-plus:after {
+            background-position: -108px -624px;
+        }
+    }
+
+    &.btn-grey,
+    &.btn-gray {
+        background-color: #e0e0e0;
+        color: #616161;
+        &:hover,
+        &:focus {
+            background-color: #686868;
+            color: #f5f5f5;
+        }
+
+        &:before {
+            background-color: #545454;
+        }
+
+        &:hover {
+            &:before {
+                background-color: #2e2e2e;
+            }
+        }
+    }
+
+    &.btn-red {
+        background-color: #9d2235;
+        color: white;
+
+        &:hover,
+        &:focus {
+            background-color: #881d2e;
+            color: #eeeeee;
+        }
+
+        &:before {
+            background-color: #881d2e;
+        }
+
+        &:hover {
+            &:before {
+                background-color: #491019;
+            }
+        }
+    }
+
+    &.btn-blue {
+        background-color: #e0e0e0;
+        color: #616161;
+
+        &:hover,
+        &:focus {
+            background-color: #1d6488;
+            color: #eeeeee;
+        }
+
+        &:before {
+            background-color: #1d6488;
+        }
+
+        &:hover {
+            &:before {
+                background-color: #103649;
+            }
+        }
+    }
+
+    &.btn-green {
+        background-color: #e0e0e0;
+        color: #616161;
+
+        &:hover,
+        &:focus {
+            background-color: #1d8843;
+            color: #eeeeee;
+        }
+
+        &:before {
+            background-color: #1d8843;
+        }
+
+        &:hover {
+            &:before {
+                background-color: #104924;
+            }
+        }
+    }
+
+    &.btn-yellow {
+        background-color: #e0e0e0;
+        color: #616161;
+
+        &:hover,
+        &:focus {
+            background-color: #ffb002;
+            color: #212121;
+        }
+
+        &:before {
+            background-color: #ffb002;
+        }
+
+        &:hover {
+            &:before {
+                background-color: #b57c00;
+            }
+        }
+    }
+
+    &:after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 55px;
+        height: 55px;
+        right: -50px;
+        top: 50%;
+        margin-top: -28px;
+        background: url(/wp-content/themes/uams-2016/assets/svg/uams-sprite.svg) no-repeat -36px -475px transparent;
+    }
+
+    &:before {
+        content: "";
+        width: 48px;
+        right: -48px;
+        top: 0;
+        bottom: 0;
+        position: absolute;
+        background-color: #9d2235;
+        border-left: 5px solid rgba(0, 0, 0, 0.3);
+    }
+
+    &.btn-play:after {
+        background-position: -34px -539px;
+    }
+
+    &.btn-external:after {
+        background-position: -146px -475px;
+    }
+
+    &.btn-plus:after {
+        background-position: -95px -539px;
+    }
 }
-a.uams-btn.btn-sm {
-  padding: 8px 14px;
-  font-size: 15px;
-  font-weight: 800;
-  border-radius: 0;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-}
-a.uams-btn.btn-sm:before {
-  width: 43px;
-  right: -43px;
-}
-a.uams-btn.btn-sm:after {
-  width: 45px;
-  height: 45px;
-  top: 50%;
-  margin-top: -21px;
-  right: -43px;
-  background-size: 740px;
-  background-position: -32px -410px;
-}
-a.uams-btn.btn-sm.btn-left {
-  margin-left: 43px;
-}
-a.uams-btn.btn-sm.btn-left:before {
-  left: -43px;
-  border-right: 5px solid rgba(0, 0, 0, 0.3);
-  border-left: none;
-}
-a.uams-btn.btn-sm.btn-left:after {
-  left: -43px;
-  margin-top: -25px;
-  transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-}
-a.uams-btn.btn-sm.btn-play:after {
-  background-position: -30px -464px;
-}
-a.uams-btn.btn-sm.btn-external:after {
-  background-position: -126px -410px;
-}
-a.uams-btn.btn-sm.btn-plus:after {
-  background-position: -83px -465px;
-}
-a.uams-btn.btn-lg {
-  padding: 16px 30px;
-  font-size: 24px;
-  font-weight: 800;
-  border-radius: 0;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-}
-a.uams-btn.btn-lg:before {
-  width: 60px;
-  right: -60px;
-}
-a.uams-btn.btn-lg:after {
-  width: 64px;
-  height: 56px;
-  top: 50%;
-  margin-top: -30px;
-  right: -60px;
-  background-size: 1000px;
-  background-position: -38px -550px;
-}
-a.uams-btn.btn-lg.btn-play:after {
-  background-position: -39px -625px;
-}
-a.uams-btn.btn-lg.btn-external:after {
-  background-position: -166px -550px;
-}
-a.uams-btn.btn-lg.btn-plus:after {
-  background-position: -108px -624px;
-}
-a.uams-btn:hover,
-a.uams-btn:focus {
-  color: #212121;
-  background-color: #9d2235;
-}
-a.uams-btn:hover:before,
-a.uams-btn:focus:before {
-  background-color: #c72b43;
-}
-a.uams-btn.btn-grey {
-  background-color: #e0e0e0;
-  color: #616161;
-}
-a.uams-btn.btn-grey:hover,
-a.uams-btn.btn-grey:focus {
-  background-color: #686868;
-  color: #f5f5f5;
-}
-a.uams-btn.btn-grey:before {
-  background-color: #545454;
-}
-a.uams-btn.btn-grey:hover:before {
-  background-color: #2e2e2e;
-}
-a.uams-btn.btn-gray {
-  background-color: #e0e0e0;
-  color: #616161;
-}
-a.uams-btn.btn-gray:hover,
-a.uams-btn.btn-gray:focus {
-  background-color: #686868;
-  color: #f5f5f5;
-}
-a.uams-btn.btn-gray:before {
-  background-color: #545454;
-}
-a.uams-btn.btn-gray:hover:before {
-  background-color: #2e2e2e;
-}
-a.uams-btn.btn-red {
-  background-color: #9d2235;
-  color: white;
-}
-a.uams-btn.btn-red:hover,
-a.uams-btn.btn-red:focus {
-  background-color: #881d2e;
-  color: #eeeeee;
-}
-a.uams-btn.btn-red:before {
-  background-color: #881d2e;
-}
-a.uams-btn.btn-red:hover:before {
-  background-color: #491019;
-}
-a.uams-btn.btn-blue {
-  background-color: #e0e0e0;
-  color: #616161;
-}
-a.uams-btn.btn-blue:hover,
-a.uams-btn.btn-blue:focus {
-  background-color: #1d6488;
-  color: #eeeeee;
-}
-a.uams-btn.btn-blue:before {
-  background-color: #1d6488;
-}
-a.uams-btn.btn-blue:hover:before {
-  background-color: #103649;
-}
-a.uams-btn.btn-green {
-  background-color: #e0e0e0;
-  color: #616161;
-}
-a.uams-btn.btn-green:hover,
-a.uams-btn.btn-green:focus {
-  background-color: #1d8843;
-  color: #eeeeee;
-}
-a.uams-btn.btn-green:before {
-  background-color: #1d8843;
-}
-a.uams-btn.btn-green:hover:before {
-  background-color: #104924;
-}
-a.uams-btn.btn-yellow {
-  background-color: #e0e0e0;
-  color: #616161;
-}
-a.uams-btn.btn-yellow:hover,
-a.uams-btn.btn-yellow:focus {
-  background-color: #ffb002;
-  color: #212121;
-}
-a.uams-btn.btn-yellow:before {
-  background-color: #ffb002;
-}
-a.uams-btn.btn-yellow:hover:before {
-  background-color: #b57c00;
-}
-a.uams-btn:after {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 55px;
-  height: 55px;
-  right: -50px;
-  top: 50%;
-  margin-top: -28px;
-  background: url(/wp-content/themes/uams-2016/assets/svg/uams-sprite.svg) no-repeat -36px -475px transparent;
-}
-a.uams-btn:before {
-  content: "";
-  width: 48px;
-  right: -48px;
-  top: 0;
-  bottom: 0;
-  position: absolute;
-  background-color: #9d2235;
-  border-left: 5px solid rgba(0, 0, 0, 0.3);
-}
-a.uams-btn.btn-play:after {
-  background-position: -34px -539px;
-}
-a.uams-btn.btn-external:after {
-  background-position: -146px -475px;
-}
-a.uams-btn.btn-plus:after {
-  background-position: -95px -539px;
-}
-#sidebar a.uams-btn {
-  width: calc(100% - 48px);
-}
-#sidebar.btn-lg {
-  width: calc(100% - 60px);
-}
-#sidebar.btn-sm {
-  width: calc(100% - 43px);
-}
-@media only screen and (max-width: 768px) {
-  #sidebar a.uams-btn {
-    width: auto;
-  }
-  #sidebar.btn-lg {
-    width: auto;
-  }
-  #sidebar.btn-sm {
-    width: auto;
-  }
+
+#sidebar {
+    a.uams-btn {
+        width: calc(100% - 48px);
+    }
+
+    &.btn-lg {
+        // This was probably intended to be nested within the a.uams-btn rule-set.
+        width: calc(100% - 60px);
+    }
+
+    &.btn-sm {
+        // This was probably intended to be nested within the a.uams-btn rule-set.
+        width: calc(100% - 43px);
+    }
+
+    a.uams-btn,
+    &.btn-lg,
+    &.bgn-sm {
+        @media only screen and (max-width: 767px) {
+            width: auto;
+        }
+    }
 }

--- a/admin/css/sass/shortcodes/class-callout.scss
+++ b/admin/css/sass/shortcodes/class-callout.scss
@@ -1,365 +1,368 @@
 .uams-callout {
-  padding: 2em;
-  margin: 1.5em 0 1.5em 0;
-  //font-size: 1.25em;
-  display: flex;
-  flex-direction: row;
- // overflow: hidden;
+    padding: 2em;
+    margin: 1.5em 0 1.5em 0;
+    //font-size: 1.25em;
+    display: flex;
+    flex-direction: row;
+    // overflow: hidden;
 
-  .callout-heading {
-    font-size: 1.8em;
-    margin-bottom: 0.25em;
+    .callout-heading {
+        font-size: 1.8em;
+        margin-bottom: 0.25em;
 
-    .heading-icon {
-      width: 100%;
-      display: block;
-      clear: both;
-      font-size: 2em;
-      //padding-bottom: 1em;
-      line-height: 1.25em;
+        .heading-icon {
+            width: 100%;
+            display: block;
+            clear: both;
+            font-size: 2em;
+            //padding-bottom: 1em;
+            line-height: 1.25em;
 
-      svg {
-        width: 1em;
-        height: 1em;
-      }
-    }
-  }
-
-  .callout-content {
-    margin: auto;
-    flex: 1 auto;
-  }
-
-  p, h1, h2, h3 {
-    //font-weight: normal;
-    margin: 0;
-  }
-
-  a, div {
-    display: block;
-  //  height: 100%;
-    width: 100%;
-  }
-
-  .textleft {
-    text-align: left;
-  }
-
-  .textcenter {
-    text-align: center;
-  }
-
-  .textright {
-    text-align: right;
-  }
-
-  &.thinmargin {
-    margin: 1em 0 1em 0;
-  }
-
-  &.nomargin {
-    margin: 0;
-  }
-
-  &.callout-media {
-    padding: 0;
-
-    &.callout-video {
-      min-height: 350px;
-    }
-
-    &.media-top,
-    &.media-bottom {
-      flex-direction: column;
+            svg {
+                width: 1em;
+                height: 1em;
+            }
+        }
     }
 
     .callout-content {
-      flex: 1 100%;
-      width: 50%;
-
-      &.media-left {
-        order: 1;
-      }
-
-      &.media-right {
-        order: 1;
-      }
-
-      &.media-top {
-        order: 2;
-        width: 100%;
-      }
-
-      &.media-bottom {
-        order: 1;
-        width: 100%;
-      }
-    }
-
-    &.callout-media-image {
-
-      .callout-content {
         margin: auto;
-      }
-    }
-  }
-
-  .callout-img {
-    max-width: 60%;
-    max-height: 100%;
-    margin: auto;
-    flex: 1 100%;
-    position: relative;
-
-    img {
-      width: 100%;
-      height: auto;
+        flex: 1 auto;
     }
 
-    &.media-left {
-      order: 1;
-      padding: 0;
+    p,
+    h1,
+    h2,
+    h3 {
+        //font-weight: normal;
+        margin: 0;
+    }
 
-      .callout-img-caption {
+    a,
+    div {
+        display: block;
+        //  height: 100%;
+        width: 100%;
+    }
+
+    .textleft {
         text-align: left;
-      }
-
-      &.bg-img {
-        margin: 0;
-        overflow: hidden;
-        
-        img {
-          height: 100%;
-          width: auto;
-          background-size: cover;
-          background-repeat: no-repeat;
-          background-position: top center;
-          max-width: initial;
-          overflow: hidden;
-        }
-      }
     }
 
-    &.media-right {
-      order: 2;
-      padding: 0;
+    .textcenter {
+        text-align: center;
+    }
 
-      .callout-img-caption {
+    .textright {
         text-align: right;
-      }
+    }
 
-      &.bg-img {
+    &.thinmargin {
+        margin: 1em 0 1em 0;
+    }
+
+    &.nomargin {
         margin: 0;
-        overflow: hidden;
-        
-        img {
-          height: 100%;
-          width: auto;
-          background-size: cover;
-          background-repeat: no-repeat;
-          background-position: top center;
-          max-width: initial;
-          overflow: hidden;
-        }
-      }
     }
-
-    &.media-top {
-      order: 1;
-      max-width: 100%;
-    }
-
-    &.media-bottom {
-      order: 2;
-      max-width: 100%;
-    }
-  }
-
-  .embed-responsive-item {
-    border: none;
-    width: 60%;
-    flex: 1 100%;
-  }
-
-  iframe {
-    margin: 0;
-  }
-
-}
-
-.callout-img-caption {
-  position: absolute;
-  bottom: -1.75em;
-  right: 0;
-  font-size: 12px;
-  color: #000;
-}
-
-.uams-callout-bgimg, .uams-callout-bgvid {
-  max-width: 1500px;
-  height: 500px;
-  position: relative;
-
-  &.thinmargin {
-    margin: 1em 0 1em 0;
-  }
-
-  &.nomargin {
-    margin: 0;
-  }
-
-  &.normal {
-    margin: 2em 0 2em 0;
-  }
-
-  .callout-media-wrapper {
-    position: absolute;
-    margin: auto;
-    height: 100%;
-    width: 100%;
-
-    .bgimg {
-      height: 100%;
-      width: 100%;
-      display: block;
-      background-position: center center !important; 
-      background-repeat: no-repeat !important; 
-      background-size: cover !important;
-    }
-
-    .embed-responsive {
-      height: 100%;
-      width: 100%;
-      display: block;
-      overflow: hidden;
-      position: relative;
-
-      .bgimg {
-        position: absolute;
-      }
-
-      video {
-        min-width: 100%; 
-        min-height: 100%;
-        width: auto;
-        height: auto;
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-
-      }
-    }
-  }
-
-  .callout-content-container {
-    position: absolute;
-    display: flex;
-    padding: 2em 2em 2em 2em;
-    height: 100%;
-    width: 100%;
-  }
-
-  .uams-callout {
-    padding: 2em;
-    font-size: 1.2em;
-    display: inline-block;
-    margin: 0;
-    position: relative;
-
-    &.left {
-      margin-right: auto;
-    }
-
-    &.right {
-      margin-left: auto;
-    }
-
-    &.center {
-      margin-left: auto;
-      margin-right: auto;
-    }
-
-    &.top {
-      margin-bottom: auto;
-    }
-
-    &.bottom {
-      margin-top: auto;
-    }
-
-    &.middle {
-      margin-top: auto;
-      margin-bottom: auto;
-    }
-  }
-}
-
-@media screen and (max-width: 992px) {
-  .uams-callout {
-    flex-direction: column;
-    font-size: 1em;
 
     &.callout-media {
-      padding: 0;
+        padding: 0;
 
-      .callout-content {
-        padding: 1.5em;
-        flex: 1 100%;
-        width: 100%;
-      }
+        &.callout-video {
+            min-height: 350px;
+        }
+
+        &.media-top,
+        &.media-bottom {
+            flex-direction: column;
+        }
+
+        .callout-content {
+            flex: 1 100%;
+            width: 50%;
+
+            &.media-left {
+                order: 1;
+            }
+
+            &.media-right {
+                order: 1;
+            }
+
+            &.media-top {
+                order: 2;
+                width: 100%;
+            }
+
+            &.media-bottom {
+                order: 1;
+                width: 100%;
+            }
+        }
+
+        &.callout-media-image {
+            .callout-content {
+                margin: auto;
+            }
+        }
     }
 
     .callout-img {
-      max-width: 100%;
-      max-height: 100%;
-      margin: 0;
-      flex: 1 100%;
+        max-width: 60%;
+        max-height: 100%;
+        margin: auto;
+        flex: 1 100%;
+        position: relative;
 
-      &.media-right,
-      &.media-left {
-        &.bg-img {
-          margin: auto;
-          img {
+        img {
             width: 100%;
             height: auto;
-          }
         }
-      }
+
+        &.media-left {
+            order: 1;
+            padding: 0;
+
+            .callout-img-caption {
+                text-align: left;
+            }
+
+            &.bg-img {
+                margin: 0;
+                overflow: hidden;
+
+                img {
+                    height: 100%;
+                    width: auto;
+                    background-size: cover;
+                    background-repeat: no-repeat;
+                    background-position: top center;
+                    max-width: initial;
+                    overflow: hidden;
+                }
+            }
+        }
+
+        &.media-right {
+            order: 2;
+            padding: 0;
+
+            .callout-img-caption {
+                text-align: right;
+            }
+
+            &.bg-img {
+                margin: 0;
+                overflow: hidden;
+
+                img {
+                    height: 100%;
+                    width: auto;
+                    background-size: cover;
+                    background-repeat: no-repeat;
+                    background-position: top center;
+                    max-width: initial;
+                    overflow: hidden;
+                }
+            }
+        }
+
+        &.media-top {
+            order: 1;
+            max-width: 100%;
+        }
+
+        &.media-bottom {
+            order: 2;
+            max-width: 100%;
+        }
     }
 
     .embed-responsive-item {
-      border: none;
-      width: 100%;
-      min-height: 400px;
-      flex: 1 100%;
+        border: none;
+        width: 60%;
+        flex: 1 100%;
     }
-  }
 
-  .uams-callout-bgvid {
+    iframe {
+        margin: 0;
+    }
+}
+
+.callout-img-caption {
+    position: absolute;
+    bottom: -1.75em;
+    right: 0;
+    font-size: 12px;
+    color: #000;
+}
+
+.uams-callout-bgimg,
+.uams-callout-bgvid {
+    max-width: 1500px;
+    height: 500px;
+    position: relative;
+
+    &.thinmargin {
+        margin: 1em 0 1em 0;
+    }
+
+    &.nomargin {
+        margin: 0;
+    }
+
+    &.normal {
+        margin: 2em 0 2em 0;
+    }
+
     .callout-media-wrapper {
-      .embed-responsive {
-        video {
-          display: none;
+        position: absolute;
+        margin: auto;
+        height: 100%;
+        width: 100%;
+
+        .bgimg {
+            height: 100%;
+            width: 100%;
+            display: block;
+            background-position: center center !important;
+            background-repeat: no-repeat !important;
+            background-size: cover !important;
         }
-      }
+
+        .embed-responsive {
+            height: 100%;
+            width: 100%;
+            display: block;
+            overflow: hidden;
+            position: relative;
+
+            .bgimg {
+                position: absolute;
+            }
+
+            video {
+                min-width: 100%;
+                min-height: 100%;
+                width: auto;
+                height: auto;
+                position: absolute;
+                left: 50%;
+                top: 50%;
+                transform: translate(-50%, -50%);
+            }
+        }
     }
-  }
 
-  .callout-media-wrapper {
-    //position: relative !important;
-    //float: left;
-  }
+    .callout-content-container {
+        position: absolute;
+        display: flex;
+        padding: 2em 2em 2em 2em;
+        height: 100%;
+        width: 100%;
+    }
 
-  .callout-content-container {
-    //position: relative !important;
-    //float: left;
-    //height: auto !important;
-    //padding: 0 !important;
-    //margin-bottom: 1em;
-  }
+    .uams-callout {
+        padding: 2em;
+        font-size: 1.2em;
+        display: inline-block;
+        margin: 0;
+        position: relative;
 
-  .uams-callout-bgimg, .uams-callout-bgvid {
-    min-height: 300px;
-  }
+        &.left {
+            margin-right: auto;
+        }
+
+        &.right {
+            margin-left: auto;
+        }
+
+        &.center {
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        &.top {
+            margin-bottom: auto;
+        }
+
+        &.bottom {
+            margin-top: auto;
+        }
+
+        &.middle {
+            margin-top: auto;
+            margin-bottom: auto;
+        }
+    }
+}
+
+@media screen and (max-width: 992px) {
+    .uams-callout {
+        flex-direction: column;
+        font-size: 1em;
+
+        &.callout-media {
+            padding: 0;
+
+            .callout-content {
+                padding: 1.5em;
+                flex: 1 100%;
+                width: 100%;
+            }
+        }
+
+        .callout-img {
+            max-width: 100%;
+            max-height: 100%;
+            margin: 0;
+            flex: 1 100%;
+
+            &.media-right,
+            &.media-left {
+                &.bg-img {
+                    margin: auto;
+                    img {
+                        width: 100%;
+                        height: auto;
+                    }
+                }
+            }
+        }
+
+        .embed-responsive-item {
+            border: none;
+            width: 100%;
+            min-height: 400px;
+            flex: 1 100%;
+        }
+    }
+
+    .uams-callout-bgvid {
+        .callout-media-wrapper {
+            .embed-responsive {
+                video {
+                    display: none;
+                }
+            }
+        }
+    }
+
+    .callout-media-wrapper {
+        //position: relative !important;
+        //float: left;
+    }
+
+    .callout-content-container {
+        //position: relative !important;
+        //float: left;
+        //height: auto !important;
+        //padding: 0 !important;
+        //margin-bottom: 1em;
+    }
+
+    .uams-callout-bgimg,
+    .uams-callout-bgvid {
+        min-height: 300px;
+    }
 }

--- a/admin/css/sass/shortcodes/class-iconbox.scss
+++ b/admin/css/sass/shortcodes/class-iconbox.scss
@@ -1,65 +1,65 @@
 /* Full Width Option */
 .uams-full-width {
-  width: 100vw;
-  margin-left: calc( 50% - 50vw);
-  margin-right: calc( 50% - 50vw);
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
 }
 /* Icon Box Shortcodes */
 .icon-box-wrapper {
-  text-align: center;
-  padding: 15px 0;
-  margin-bottom: 1em;
+    text-align: center;
+    padding: 15px 0;
+    margin-bottom: 1em;
 }
 .uams-body-copy .icon-box-icon a,
 .icon-box-icon a {
-  border-bottom: none;
+    border-bottom: none;
 }
 .uams-body .icon-box-icon a:focus:not(.uams-btn),
 .uams-body .icon-box-icon a:hover:not(.uams-btn),
-.icon-box-icon a:focus, 
+.icon-box-icon a:focus,
 .icon-box-icon a:hover {
-  border-bottom: none;
+    border-bottom: none;
 }
 .icon-box-icon a span,
-.icon-box-icon .icon-wrap span { 
-  display: inline-block;
-  padding: 18px;
-  border-radius: 100%;
-  background-color: transparent;
-  border: 3px solid transparent; //Make same as bg color
+.icon-box-icon .icon-wrap span {
+    display: inline-block;
+    padding: 18px;
+    border-radius: 100%;
+    background-color: transparent;
+    border: 3px solid transparent; //Make same as bg color
 }
 .icon-box-icon a span:focus,
 .icon-box-icon a span:hover {
-  border-color: rgba(21, 101, 192, 0.75);
+    border-color: rgba(21, 101, 192, 0.75);
 }
 .icon-box-content h3.icon-box-title {
-  margin-top: 0;
+    margin-top: 0;
 }
 .icon-box-content a h3.icon-box-title {
-  color: #9d2235;
-  display: inline-block;
+    color: #9d2235;
+    display: inline-block;
 }
 .icon-box-wrapper a.icon-box-tile-link,
 .icon-box-wrapper a.icon-box-tile-link:hover,
 .icon-box-wrapper a.icon-box-tile-link:focus {
-  border-bottom-color: #9d2235;
+    border-bottom-color: #9d2235;
 }
 .icon-box-content {
-  padding: 65px 20px 10px;
-  margin-top: -55px;
+    padding: 65px 20px 10px;
+    margin-top: -55px;
 }
 /* Options */
 .icon-box-wrapper.default.none {
-  background-color: transparent;
+    background-color: transparent;
 }
 .icon-box-wrapper.default.gray {
-  background-color: #eee;
+    background-color: #eee;
 }
 .icon-box-wrapper.default.red {
-  background-color: #9d2235;
+    background-color: #9d2235;
 }
 .icon-box-wrapper.default.blue {
-  background-color: #22739d;
+    background-color: #22739d;
 }
 .icon-box-wrapper.default.red a.icon-box-tile-link,
 .icon-box-wrapper.default.red a.icon-box-tile-link:hover,
@@ -73,50 +73,52 @@
 .icon-box-wrapper.boxed.blue a.icon-box-tile-link,
 .icon-box-wrapper.boxed.blue a.icon-box-tile-link:hover,
 .icon-box-wrapper.boxed.blue a.icon-box-tile-link:focus {
-  border-bottom-color: #fff;
+    border-bottom-color: #fff;
 }
 .icon-box-icon.default span:before {
-  color: #e0e0e0;
+    color: #e0e0e0;
 }
 .icon-box-wrapper .icon-box-icon span:before {
-  color: #e0e0e0;
+    color: #e0e0e0;
 }
 .icon-box-wrapper.gray .icon-box-icon span:before {
-  color: #616161;
+    color: #616161;
 }
 .icon-box-wrapper.red .icon-box-icon span:before {
-  color: #9d2235;
+    color: #9d2235;
 }
 .icon-box-wrapper.blue .icon-box-icon span:before {
-  color: #22739d;
+    color: #22739d;
 }
 .icon-box-wrapper.default.none .icon-box-icon span:before {
-  color: #e0e0e0;
+    color: #e0e0e0;
 }
 .icon-box-wrapper.default.gray .icon-box-icon span:before {
-  color: #616161;
+    color: #616161;
 }
 .icon-box-wrapper.default.red .icon-box-icon span:before,
 .icon-box-wrapper.default.blue .icon-box-icon span:before {
-  color: #fafafa;
+    color: #fafafa;
 }
 .icon-box-wrapper.default.red .icon-box-icon span:hover,
 .icon-box-wrapper.default.red .icon-box-icon span:focus,
 .icon-box-wrapper.default.blue .icon-box-icon span:hover,
 .icon-box-wrapper.default.blue .icon-box-icon span:focus {
-  border-color: #fafafa;
-}
-.icon-box-wrapper.default.red a h3.icon-box-title, .icon-box-wrapper.default.red a h3,
-.icon-box-wrapper.default.blue a h3.icon-box-title, .icon-box-wrapper.default.blue a h3 {
-  color: #fff;
+    border-color: #fafafa;
 }
 .icon-box-wrapper.default.red a h3.icon-box-title,
-.icon-box-wrapper.boxed.red a h3.icon-box-title  {
-  color: #fff;
+.icon-box-wrapper.default.red a h3,
+.icon-box-wrapper.default.blue a h3.icon-box-title,
+.icon-box-wrapper.default.blue a h3 {
+    color: #fff;
+}
+.icon-box-wrapper.default.red a h3.icon-box-title,
+.icon-box-wrapper.boxed.red a h3.icon-box-title {
+    color: #fff;
 }
 .icon-box-wrapper.default.blue a h3.icon-box-title,
 .icon-box-wrapper.boxed.blue a h3.icon-box-title {
-  color: #fff;
+    color: #fff;
 }
 .icon-box-wrapper.default.red a.icon-box-tile-link,
 .icon-box-wrapper.default.red a.icon-box-tile-link:hover,
@@ -124,87 +126,86 @@
 .icon-box-wrapper.default.blue a.icon-box-tile-link,
 .icon-box-wrapper.default.blue a.icon-box-tile-link:hover,
 .icon-box-wrapper.default.blue a.icon-box-tile-link:focus {
-  border-bottom-color: #fff;
+    border-bottom-color: #fff;
 }
 .icon-box-wrapper.default.red .icon-box-description,
 .icon-box-wrapper.default.blue .icon-box-description,
 .icon-box-wrapper.boxed.red .icon-box-description,
 .icon-box-wrapper.boxed.blue .icon-box-description {
-  color: #fff;
+    color: #fff;
 }
 .icon-box-wrapper.boxed.red .icon-box-content {
-  background-color: #9d2235;
+    background-color: #9d2235;
 }
 .icon-box-wrapper.boxed.blue .icon-box-content {
-  background-color: #22739d;
+    background-color: #22739d;
 }
 .icon-box-wrapper.boxed.gray .icon-box-content {
-  background-color: #eee;
+    background-color: #eee;
 }
 .icon-box-wrapper.boxed.gray .icon-box-icon a span,
-.icon-box-wrapper.boxed.gray .icon-box-icon .icon-wrap span  {
-  border-color: #eee;
-  background-color: #fff;
+.icon-box-wrapper.boxed.gray .icon-box-icon .icon-wrap span {
+    border-color: #eee;
+    background-color: #fff;
 }
 .icon-box-wrapper.boxed.blue .icon-box-icon a span,
 .icon-box-wrapper.boxed.blue .icon-box-icon .icon-wrap span {
-  border-color: #22739d;
-  background-color: #fff;
+    border-color: #22739d;
+    background-color: #fff;
 }
 .icon-box-wrapper.boxed.red .icon-box-icon a span,
 .icon-box-wrapper.boxed.red .icon-box-icon .icon-wrap span {
-  border-color: #9d2235;
-  background-color: #fff;
+    border-color: #9d2235;
+    background-color: #fff;
 }
 .icon-box-wrapper.framed.gray .icon-box-icon a span,
 .icon-box-wrapper.framed.gray .icon-box-icon .icon-wrap span {
-  background-color: #eee;
+    background-color: #eee;
 }
 .icon-box-wrapper.framed.blue .icon-box-icon a span,
 .icon-box-wrapper.framed.blue .icon-box-icon .icon-wrap span {
-  background-color: #22739d;
+    background-color: #22739d;
 }
 .icon-box-wrapper.framed.red .icon-box-icon a span,
 .icon-box-wrapper.framed.red .icon-box-icon .icon-wrap span {
-  background-color: #9d2235;
+    background-color: #9d2235;
 }
 .icon-box-wrapper.framed.gray .icon-box-icon span:before {
-  color: #616161;
+    color: #616161;
 }
 .icon-box-wrapper.framed.red .icon-box-icon span:before,
 .icon-box-wrapper.framed.blue .icon-box-icon span:before {
-  color: #fff;
+    color: #fff;
 }
 
 /* Responsive Fixes */
 @media (min-width: 768px) {
-  .icon-box-content {
-    max-width: 750px;
-    margin: -55px auto 0;
-  }
-  .text-box-content {
-    max-width: 750px;
-    margin: 0 auto;
-  }
+    .icon-box-content {
+        max-width: 750px;
+        margin: -55px auto 0;
+    }
+    .text-box-content {
+        max-width: 750px;
+        margin: 0 auto;
+    }
 }
 @media (min-width: 992px) {
-  .icon-box-content {
-    max-width: 970px;
-    margin: -55px auto 0;
-  }
-  .text-box-content {
-    max-width: 970px;
-    margin: 0 auto;
-  }
+    .icon-box-content {
+        max-width: 970px;
+        margin: -55px auto 0;
+    }
+    .text-box-content {
+        max-width: 970px;
+        margin: 0 auto;
+    }
 }
 @media (min-width: 1200px) {
-  .icon-box-content {
-    max-width: 1170px;
-    margin: -55px auto 0;
-  }
-  .text-box-content {
-    max-width: 1170px;
-    margin: 0 auto;
-  }
+    .icon-box-content {
+        max-width: 1170px;
+        margin: -55px auto 0;
+    }
+    .text-box-content {
+        max-width: 1170px;
+        margin: 0 auto;
+    }
 }
-


### PR DESCRIPTION
Presuming the Bootstrap CSS is included elsewhere in the themes, this _should_ be fine.

Not sure if you should build a different master for UAMS-2020 and beyond, though.